### PR TITLE
(PLATFORM-5172) Remove nCanonicalNamespaces hook

### DIFF
--- a/DPLForumHooks.php
+++ b/DPLForumHooks.php
@@ -20,18 +20,4 @@ class DPLForumHooks {
 		$f = new DPLForum();
 		return $f->parse( $input, $parser );
 	}
-
-	/**
-	 * Register the canonical names for our namespace and its talkspace.
-	 *
-	 * @param array $list Array of namespace numbers with corresponding
-	 *                     canonical names
-	 * @return bool true
-	 */
-	public static function onCanonicalNamespaces( &$list ) {
-		$list[NS_FORUM] = 'Forum';
-		$list[NS_FORUM_TALK] = 'Forum_talk';
-		return true;
-	}
-
 }

--- a/extension.json
+++ b/extension.json
@@ -34,9 +34,6 @@
 	"Hooks": {
 		"ParserFirstCallInit": [
 			"DPLForumHooks::onParserFirstCallInit"
-		],
-		"CanonicalNamespaces": [
-			"DPLForumHooks::onCanonicalNamespaces"
 		]
 	},
 	"manifest_version": 1


### PR DESCRIPTION
These namespaces are now defined in extension.json already, so there is no need
to redefine them in a hook anymore which was the legacy way, and it prevents us
overridding the namespace list in this hook going forward.

This is a simple change we can also push upstream if we want.

/cc @Wikia/core-platform-team 